### PR TITLE
Avoid holding the command queue lock while running commands

### DIFF
--- a/AlmondShell/include/acommandqueue.hpp
+++ b/AlmondShell/include/acommandqueue.hpp
@@ -19,11 +19,16 @@ namespace almondnamespace::core {
         }
 
         bool drain() {
-            std::scoped_lock lock(mutex);
-            if (commands.empty()) return false;
-            while (!commands.empty()) {
-                auto cmd = std::move(commands.front());
-                commands.pop();
+            std::queue<RenderCommand> localCommands;
+            {
+                std::scoped_lock lock(mutex);
+                if (commands.empty()) return false;
+                localCommands.swap(commands);
+            }
+
+            while (!localCommands.empty()) {
+                auto cmd = std::move(localCommands.front());
+                localCommands.pop();
                 if (cmd) cmd();
             }
             return true;


### PR DESCRIPTION
## Summary
- avoid holding the command queue mutex while draining commands
- move queued commands into a local queue before execution to prevent deadlocks

## Testing
- cmake -S AlmondShell -B build
- cmake --build build *(fails: missing dependency asio.hpp)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe91ee6848333bdfbef4803c8ce92