### PR TITLE
Handle missing files in file watcher

### DIFF
--- a/AlmondShell/src/afilewatch.cpp
+++ b/AlmondShell/src/afilewatch.cpp
@@ -38,14 +38,31 @@ namespace almondnamespace
 
     std::vector<file_state> get_file_states(const std::string& folder) {
         std::vector<file_state> result;
-        for (const auto& entry : fs::directory_iterator(folder)) {
-            if (entry.path().extension() == ".cpp") {
+
+        std::error_code ec;
+        if (!fs::exists(folder, ec) || ec) {
+            return result;
+        }
+
+        for (const auto& entry : fs::directory_iterator(folder, ec)) {
+            if (ec) {
+                break;
+            }
+
+            if (entry.is_regular_file() && entry.path().extension() == ".cpp") {
                 file_state fs;
                 fs.path = entry.path().string();
-                fs.last_write_time = fs::last_write_time(entry).time_since_epoch().count();
+
+                auto last_write = fs::last_write_time(entry, ec);
+                if (ec) {
+                    ec.clear();
+                    continue;
+                }
+
+                fs.last_write_time = last_write.time_since_epoch().count();
                 fs.hash = fake_hash(fs.path);
                 fs.dirty = false;
-                result.push_back(fs);
+                result.push_back(std::move(fs));
             }
         }
         return result;
@@ -53,7 +70,16 @@ namespace almondnamespace
 
     void scan_and_mark_changes(std::vector<file_state>& files) {
         for (auto& f : files) {
-            auto new_time = fs::last_write_time(f.path).time_since_epoch().count();
+            std::error_code ec;
+            auto write_time = fs::last_write_time(f.path, ec);
+            if (ec) {
+                f.last_write_time = 0;
+                f.hash = 0;
+                f.dirty = true;
+                continue;
+            }
+
+            auto new_time = write_time.time_since_epoch().count();
             if (new_time != f.last_write_time) {
                 f.last_write_time = new_time;
                 f.dirty = true;


### PR DESCRIPTION
## Summary
- make the file watcher resilient to missing directories and IO failures
- mark missing files as dirty instead of throwing when probing timestamps

## Testing
- cmake -S AlmondShell -B build
- cmake --build build *(fails: asio.hpp missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfefd398c08333b74ef1c6ba322156