### PR TITLE
Fix updater binary replacement on Unix

### DIFF
--- a/AlmondShell/include/abuildsystem.hpp
+++ b/AlmondShell/include/abuildsystem.hpp
@@ -325,9 +325,9 @@ namespace almondnamespace
 #endif
 #else
 #ifdef LEAVE_NO_FILES_ALWAYS_REDOWNLOAD
-            system("rm -rf build.ninja llvm.zip llvm_installer source_code.zip updater_new 7z_installer Cpp_Ultimate_Project_Updater-main ninja");
+            system("rm -rf build.ninja llvm.zip llvm_installer source_code.zip 7z_installer Cpp_Ultimate_Project_Updater-main ninja");
 #else
-            system("rm -rf build.ninja llvm.zip llvm_installer source_code.zip updater_new 7z_installer Cpp_Ultimate_Project_Updater-main");
+            system("rm -rf build.ninja llvm.zip llvm_installer source_code.zip 7z_installer Cpp_Ultimate_Project_Updater-main");
 #endif
 #endif
         }

--- a/AlmondShell/include/aupdatesystem.hpp
+++ b/AlmondShell/include/aupdatesystem.hpp
@@ -186,11 +186,13 @@ namespace almondnamespace
         inline bool install_from_binary(const std::string& binary_url) {
             std::cout << "[INFO] Installing from precompiled binary...\n";
 
-            if (!download_file(binary_url, "updater_new.exe")) {
+            const std::string output_binary = OUTPUT_BINARY();
+
+            if (!download_file(binary_url, output_binary)) {
                 std::cerr << "[ERROR] Failed to download precompiled binary!\n";
                 return false;
             }
-            replace_binary("updater_new.exe");
+            replace_binary(output_binary);
 
             return true;
         }
@@ -261,7 +263,7 @@ namespace almondnamespace
             // you can reverse the redunant fallback order from "binary to source" to "source to binary" in download/usage order
             // by using this and altering the update_from_source() function differently, add binary_url to install_from_source(const std::string& binary_url) 
             //install_from_binary(binary_url);
-            replace_binary("updater_new.exe");
+            replace_binary(OUTPUT_BINARY());
         }
 
         // 🔄 **Update from Source (Minimal)**


### PR DESCRIPTION
## Summary
- stop the Linux cleanup routine from deleting the freshly downloaded updater binary before it can be installed
- use the configured updater output filename instead of a hard coded Windows name when downloading or installing updates

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cff95ede70833392a13110559e907f