### PR TITLE
Fix OpenGL multi-context texture handling and menu sprites

### DIFF
--- a/AlmondShell/include/aopenglcontext.hpp
+++ b/AlmondShell/include/aopenglcontext.hpp
@@ -59,6 +59,7 @@
 #include <functional>
 #include <mutex>
 #include <queue>
+#include <algorithm>
 
 namespace almondnamespace::openglcontext
 {
@@ -105,136 +106,7 @@ namespace almondnamespace::openglcontext
         return program;
     }
 
-    // — Engine hooks
-    inline bool opengl_initialize(std::shared_ptr<core::Context> ctx,
-        HWND parentWnd = nullptr,
-        unsigned int w = 800,
-        unsigned int h = 600,
-        std::function<void(int, int)> onResize = nullptr)
-    {
-        static bool initialized = false;
-        if (initialized) return true;
-        initialized = true;
-
-
-        auto& backend = almondnamespace::opengltextures::get_opengl_backend();
-        auto& glState = backend.glState;
-
-        std::cerr << "[OpenGL Init] Starting initialization\n";
-
-        // -----------------------------------------------------------------
-        // Step 1: Resolve window/context handles
-        // -----------------------------------------------------------------
-        HWND   resolvedHwnd = nullptr;
-        HDC    resolvedHdc = nullptr;
-        HGLRC  resolvedHglrc = nullptr;
-
-        if (ctx && ctx->windowData) {
-            resolvedHwnd = ctx->windowData->hwnd;
-            resolvedHdc = ctx->windowData->hdc;
-            resolvedHglrc = ctx->windowData->glContext;
-            std::cerr << "[OpenGL Init] Using ctx->windowData handles\n";
-        }
-
-        // Fallbacks: pull directly from current thread
-        if (!resolvedHdc)   resolvedHdc = wglGetCurrentDC();
-        if (!resolvedHglrc) resolvedHglrc = wglGetCurrentContext();
-
-        // Parent HWND priority
-        HWND resolvedParent = parentWnd ? parentWnd : resolvedHwnd;
-
-        // Assign hwnd only if we actually resolved one
-        if (resolvedHwnd) {
-            glState.hwnd = resolvedHwnd;
-            std::cerr << "[OpenGL Init] Using resolved hwnd=" << resolvedHwnd << "\n";
-        }
-        else if (parentWnd) {
-            glState.hwnd = parentWnd;
-            std::cerr << "[OpenGL Init] Using parent hwnd=" << parentWnd << "\n";
-        }
-        else {
-            // Leave glState.hwnd unchanged if it was already set earlier
-            std::cerr << "[OpenGL Init] WARNING: No hwnd resolved; keeping existing glState.hwnd="
-                << glState.hwnd << "\n";
-        }
-
-        // Always update HDC / HGLRC from current thread
-        glState.hdc = resolvedHdc;
-        glState.hglrc = resolvedHglrc;
-        glState.parent = resolvedParent;
-
-        std::cerr << "[OpenGL Init] Final handles: hwnd=" << glState.hwnd
-            << " hdc=" << glState.hdc
-            << " hglrc=" << glState.hglrc << "\n";
-
-        // -----------------------------------------------------------------
-        // Step 2: Cache size and callback into Context
-        // -----------------------------------------------------------------
-        ctx->width = static_cast<int>(w);
-        ctx->height = static_cast<int>(h);
-        ctx->onResize = std::move(onResize);
-
-
-        if (!glState.hwnd) {
-            glState.hwnd = CreateWindowEx(
-                0, L"AlmondChild", L"working",
-                WS_CHILD | WS_VISIBLE | WS_BORDER,
-                CW_USEDEFAULT, CW_USEDEFAULT, w, h,
-                glState.parent, nullptr, nullptr, nullptr);
-        }
-
-        if (!glState.hwnd)
-            throw std::runtime_error("[OpenGLContext] Failed to create child window");
-
-        ShowWindow(glState.hwnd, SW_SHOW);
-
-        // Device context
-        glState.hdc = GetDC(glState.hwnd);
-        if (!glState.hdc)
-            throw std::runtime_error("GetDC failed");
-
-        PIXELFORMATDESCRIPTOR pfd = { sizeof(pfd), 1,
-            PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
-            PFD_TYPE_RGBA, 32, 0,0,0,0,0,0,0,0,0,24,0,0,0,0,0,0,0 };
-
-        int pf = ChoosePixelFormat(glState.hdc, &pfd);
-        if (!pf) throw std::runtime_error("ChoosePixelFormat failed");
-        if (!SetPixelFormat(glState.hdc, pf, &pfd))
-            throw std::runtime_error("SetPixelFormat failed");
-
-        // Temporary context to load extensions
-        HGLRC tmpContext = wglCreateContext(glState.hdc);
-        if (!tmpContext) throw std::runtime_error("wglCreateContext failed");
-        if (!wglMakeCurrent(glState.hdc, tmpContext))
-            throw std::runtime_error("wglMakeCurrent failed");
-
-        auto wglCreateContextAttribsARB =
-            (PFNWGLCREATECONTEXTATTRIBSARBPROC)LoadGLFunc("wglCreateContextAttribsARB");
-        if (!wglCreateContextAttribsARB)
-            throw std::runtime_error("Failed to load wglCreateContextAttribsARB");
-
-        int attribs[] = {
-            WGL_CONTEXT_MAJOR_VERSION_ARB, 4,
-            WGL_CONTEXT_MINOR_VERSION_ARB, 6,
-            WGL_CONTEXT_PROFILE_MASK_ARB,  WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
-            0
-        };
-
-        glState.hglrc = wglCreateContextAttribsARB(glState.hdc, nullptr, attribs);
-        if (!glState.hglrc)
-            throw std::runtime_error("Failed to create OpenGL 4.6 context");
-
-        wglMakeCurrent(nullptr, nullptr);
-        wglDeleteContext(tmpContext);
-
-        if (!wglMakeCurrent(glState.hdc, glState.hglrc))
-            throw std::runtime_error("Failed to make OpenGL context current");
-
-        if (!gladLoadGL())
-            throw std::runtime_error("Failed to initialize GLAD");
-
-        // Compile & link shaders (vertex and fragment)
-        constexpr auto vs_source = R"(
+    constexpr const char kSpriteVS[] = R"(
         #version 460 core
 
         layout(location = 0) in vec2 aPos;       // [-0.5..0.5] quad coords
@@ -252,7 +124,7 @@ namespace almondnamespace::openglcontext
         }
     )";
 
-        constexpr auto fs_source = R"(
+    constexpr const char kSpriteFS[] = R"(
         #version 460 core
         in vec2 vUV;
         out vec4 outColor;
@@ -264,26 +136,42 @@ namespace almondnamespace::openglcontext
         }
     )";
 
+    inline void ensure_shared_resources(opengltextures::BackendData& backend)
+    {
+        auto& glState = backend.glState;
 
-        // Compile shader program
-        glState.shader = linkProgram(vs_source, fs_source);
-        glState.uUVRegionLoc = glGetUniformLocation(glState.shader, "uUVRegion");
-        glState.uTransformLoc = glGetUniformLocation(glState.shader, "uTransform");
-        glState.uSamplerLoc = glGetUniformLocation(glState.shader, "uTexture");
+        if (!GLAD_GL_VERSION_1_0) {
+            if (!gladLoadGL()) {
+                throw std::runtime_error("Failed to initialize GLAD");
+            }
+        }
 
-        glUseProgram(glState.shader);
-        if (glState.uSamplerLoc >= 0)
-            glUniform1i(glState.uSamplerLoc, 0);
-        glUseProgram(0);
+        if (glState.shader == 0) {
+            glState.shader = linkProgram(kSpriteVS, kSpriteFS);
+            glState.uUVRegionLoc = glGetUniformLocation(glState.shader, "uUVRegion");
+            glState.uTransformLoc = glGetUniformLocation(glState.shader, "uTransform");
+            glState.uSamplerLoc = glGetUniformLocation(glState.shader, "uTexture");
 
-        std::cerr << "[OpenGL Init] Shader program compiled/linked\n";
+            glUseProgram(glState.shader);
+            if (glState.uSamplerLoc >= 0) {
+                glUniform1i(glState.uSamplerLoc, 0);
+            }
+            glUseProgram(0);
 
-        // -----------------------------------------------------------------
-        // Step 8: Quad VAO/VBO/EBO
-        // -----------------------------------------------------------------
-        glGenVertexArrays(1, &glState.vao);
-        glGenBuffers(1, &glState.vbo);
-        glGenBuffers(1, &glState.ebo);
+            atlasmanager::ensure_uploaded_backend = [](const TextureAtlas& atlas) {
+                opengltextures::ensure_uploaded(atlas);
+            };
+        }
+
+        if (glState.vao == 0) {
+            glGenVertexArrays(1, &glState.vao);
+        }
+        if (glState.vbo == 0) {
+            glGenBuffers(1, &glState.vbo);
+        }
+        if (glState.ebo == 0) {
+            glGenBuffers(1, &glState.ebo);
+        }
 
         glBindVertexArray(glState.vao);
 
@@ -301,51 +189,209 @@ namespace almondnamespace::openglcontext
         glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
 
         glEnableVertexAttribArray(1);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
         glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)(2 * sizeof(float)));
 
-        constexpr unsigned int quadIndices[] = { 
+        constexpr unsigned int quadIndices[] = {
             0, 1, 2,
-            2, 3, 0 
+            2, 3, 0
         };
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, glState.ebo);
         glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(quadIndices), quadIndices, GL_STATIC_DRAW);
 
         glBindVertexArray(0);
+    }
 
-        std::cerr << "[OpenGL Init] Quad VAO/VBO/EBO created\n";
+    // — Engine hooks
+    inline bool opengl_initialize(std::shared_ptr<core::Context> ctx,
+        HWND parentWnd = nullptr,
+        unsigned int w = 800,
+        unsigned int h = 600,
+        std::function<void(int, int)> onResize = nullptr)
+    {
+        auto& backend = almondnamespace::opengltextures::get_opengl_backend();
+        auto& glState = backend.glState;
 
-        // -----------------------------------------------------------------
-        // Step 9: Hook texture uploads
-        // -----------------------------------------------------------------
-        atlasmanager::ensure_uploaded_backend = [](const TextureAtlas& atlas) {
-            opengltextures::ensure_uploaded(atlas);
+        HWND resolvedHwnd = nullptr;
+        HDC  resolvedHdc = nullptr;
+        HGLRC resolvedHglrc = nullptr;
+
+        if (ctx) {
+            if (ctx->windowData) {
+                resolvedHwnd = ctx->windowData->hwnd;
+                resolvedHdc = ctx->windowData->hdc;
+                resolvedHglrc = ctx->windowData->glContext;
+            }
+            if (!resolvedHwnd) resolvedHwnd = ctx->hwnd;
+            if (!resolvedHdc) resolvedHdc = ctx->hdc;
+            if (!resolvedHglrc) resolvedHglrc = ctx->hglrc;
+        }
+
+        if (!resolvedHdc)   resolvedHdc = wglGetCurrentDC();
+        if (!resolvedHglrc) resolvedHglrc = wglGetCurrentContext();
+        if (!resolvedHwnd && resolvedHdc) resolvedHwnd = WindowFromDC(resolvedHdc);
+
+        auto syncContext = [&](HWND hwnd, HDC hdc, HGLRC hglrc) {
+            if (parentWnd) {
+                glState.parent = parentWnd;
+            }
+            glState.hwnd = hwnd;
+            glState.hdc = hdc;
+            glState.hglrc = hglrc;
+            glState.width = w;
+            glState.height = h;
+            glState.onResize = onResize;
+            if (ctx) {
+                ctx->hwnd = hwnd;
+                ctx->hdc = hdc;
+                ctx->hglrc = hglrc;
+                ctx->width = static_cast<int>(w);
+                ctx->height = static_cast<int>(h);
+                ctx->onResize = onResize;
+                ctx->draw_sprite = opengltextures::draw_sprite;
+            }
+        };
+
+        if (resolvedHdc && resolvedHglrc) {
+            syncContext(resolvedHwnd, resolvedHdc, resolvedHglrc);
+
+            HGLRC prevCtx = wglGetCurrentContext();
+            HDC prevDC = wglGetCurrentDC();
+            bool switched = false;
+            if (resolvedHglrc && resolvedHdc && prevCtx != resolvedHglrc) {
+                if (wglMakeCurrent(resolvedHdc, resolvedHglrc)) {
+                    switched = true;
+                }
+            }
+
+            ensure_shared_resources(backend);
+
+            if (switched) {
+                if (prevCtx && prevDC) {
+                    wglMakeCurrent(prevDC, prevCtx);
+                }
+                else {
+                    wglMakeCurrent(nullptr, nullptr);
+                }
+            }
+            return true;
+        }
+
+        if (!parentWnd && !glState.parent) {
+            glState.parent = nullptr;
+        }
+
+        if (!glState.hwnd) {
+            glState.hwnd = CreateWindowEx(
+                0, L"AlmondChild", L"working",
+                WS_CHILD | WS_VISIBLE | WS_BORDER,
+                CW_USEDEFAULT, CW_USEDEFAULT, w, h,
+                glState.parent, nullptr, nullptr, nullptr);
+        }
+
+        if (!glState.hwnd) {
+            throw std::runtime_error("[OpenGLContext] Failed to create window");
+        }
+
+        ShowWindow(glState.hwnd, SW_SHOW);
+
+        if (!glState.hdc) {
+            glState.hdc = GetDC(glState.hwnd);
+        }
+        if (!glState.hdc) {
+            throw std::runtime_error("GetDC failed");
+        }
+
+        PIXELFORMATDESCRIPTOR pfd = { sizeof(pfd), 1,
+            PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
+            PFD_TYPE_RGBA, 32, 0,0,0,0,0,0,0,0,0,24,0,0,0,0,0,0,0 };
+
+        int pf = ChoosePixelFormat(glState.hdc, &pfd);
+        if (!pf || !SetPixelFormat(glState.hdc, pf, &pfd)) {
+            throw std::runtime_error("Failed to set pixel format");
+        }
+
+        if (!glState.hglrc) {
+            HGLRC tmpContext = wglCreateContext(glState.hdc);
+            if (!tmpContext) {
+                throw std::runtime_error("wglCreateContext failed");
+            }
+            if (!wglMakeCurrent(glState.hdc, tmpContext)) {
+                wglDeleteContext(tmpContext);
+                throw std::runtime_error("wglMakeCurrent failed");
+            }
+
+            auto wglCreateContextAttribsARB =
+                (PFNWGLCREATECONTEXTATTRIBSARBPROC)LoadGLFunc("wglCreateContextAttribsARB");
+            if (!wglCreateContextAttribsARB) {
+                wglMakeCurrent(nullptr, nullptr);
+                wglDeleteContext(tmpContext);
+                throw std::runtime_error("Failed to load wglCreateContextAttribsARB");
+            }
+
+            int attribs[] = {
+                WGL_CONTEXT_MAJOR_VERSION_ARB, 4,
+                WGL_CONTEXT_MINOR_VERSION_ARB, 6,
+                WGL_CONTEXT_PROFILE_MASK_ARB,  WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
+                0
             };
 
-        // -----------------------------------------------------------------
-        // Step 10: Sync context with GL state
-        // -----------------------------------------------------------------
-        ctx->hwnd = glState.hwnd;
-        ctx->hdc = glState.hdc;
-        ctx->hglrc = glState.hglrc;
+            glState.hglrc = wglCreateContextAttribsARB(glState.hdc, nullptr, attribs);
+            wglMakeCurrent(nullptr, nullptr);
+            wglDeleteContext(tmpContext);
 
-        std::cerr << "[OpenGL Init] Context sync complete\n";
+            if (!glState.hglrc) {
+                throw std::runtime_error("Failed to create OpenGL 4.6 context");
+            }
+        }
+
+        if (!wglMakeCurrent(glState.hdc, glState.hglrc)) {
+            throw std::runtime_error("Failed to make OpenGL context current");
+        }
+
+        syncContext(glState.hwnd, glState.hdc, glState.hglrc);
+        ensure_shared_resources(backend);
+        wglMakeCurrent(nullptr, nullptr);
+
         return true;
 }
 
     inline void opengl_present() {
+        if (HDC current = wglGetCurrentDC()) {
+            SwapBuffers(current);
+            return;
+        }
+
         auto& backend = opengltextures::get_opengl_backend();
-        auto& glState = backend.glState;        // IMPORTANT: attach our static state
-        SwapBuffers(glState.hdc);
+        auto& glState = backend.glState;
+        if (glState.hdc) {
+            SwapBuffers(glState.hdc);
+        }
     }
 
     //   inline void opengl_pump() { almondnamespace::platform::pump_events(); }
-    inline int  opengl_get_width() { 
-        RECT r; GetClientRect(s_openglstate.hwnd, &r); return r.right - r.left; 
+    inline int  opengl_get_width() {
+        if (HDC current = wglGetCurrentDC()) {
+            if (HWND hwnd = WindowFromDC(current)) {
+                RECT r{};
+                if (GetClientRect(hwnd, &r)) {
+                    return r.right - r.left;
+                }
+            }
+        }
+        auto& backend = opengltextures::get_opengl_backend();
+        return static_cast<int>(backend.glState.width);
     }
-    inline int  opengl_get_height() { 
-        RECT r; GetClientRect(s_openglstate.hwnd, &r); return r.bottom - r.top;
+    inline int  opengl_get_height() {
+        if (HDC current = wglGetCurrentDC()) {
+            if (HWND hwnd = WindowFromDC(current)) {
+                RECT r{};
+                if (GetClientRect(hwnd, &r)) {
+                    return r.bottom - r.top;
+                }
+            }
+        }
+        auto& backend = opengltextures::get_opengl_backend();
+        return static_cast<int>(backend.glState.height);
     }
     inline void opengl_clear(core::Context& ctx) {
         glViewport(0, 0, ctx.width, ctx.height);
@@ -368,6 +414,9 @@ namespace almondnamespace::openglcontext
         }
 
         if (!wglMakeCurrent(ctx.hdc, ctx.hglrc)) return true;
+
+        glState.width = static_cast<unsigned int>(std::max(0, ctx.width));
+        glState.height = static_cast<unsigned int>(std::max(0, ctx.height));
 
         // ─── Time & events ──────────────────────────────────────────────────────
         //static auto lastReal = std::chrono::steady_clock::now();
@@ -398,50 +447,6 @@ namespace almondnamespace::openglcontext
             SwapBuffers(ctx.hdc);
             wglMakeCurrent(nullptr, nullptr);
             return true;
-        }
-
-        if (!atlasmanager::atlas_vector.empty()) {
-            const auto* atlas = atlasmanager::atlas_vector[0];
-            auto it = backend.gpu_atlases.find(atlas);
-            if (it != backend.gpu_atlases.end()) {
-                GLuint tex = it->second.textureHandle;
-
-                if (tex == 0) {
-                    std::cerr << "[OpenGL] Warning: texture handle is 0\n";
-                }
-                else {
-                    glUseProgram(glState.shader);
-                    glBindVertexArray(glState.vao);
-
-                    glActiveTexture(GL_TEXTURE0);
-                    glBindTexture(GL_TEXTURE_2D, tex);
-
-                    if (glState.uTransformLoc >= 0)
-                        glUniform4f(glState.uTransformLoc,
-                            0.0f, 0.0f,   // center
-                            2.0f, 2.0f);  // span whole screen
-
-                    if (glState.uUVRegionLoc >= 0)
-                        glUniform4f(glState.uUVRegionLoc,
-                            0.0f, 0.0f,
-                            1.0f, 1.0f);
-
-                    // Double-check bound EBO before drawing
-                    GLint boundEbo = 0;
-                    glGetIntegerv(GL_ELEMENT_ARRAY_BUFFER_BINDING, &boundEbo);
-                    if (boundEbo == 0) {
-                        std::cerr << "[OpenGL] No element buffer bound!\n";
-                    }
-                    else {
-                        glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
-                    }
-
-                    // Unbind for hygiene
-                    glBindVertexArray(0);
-                    glBindTexture(GL_TEXTURE_2D, 0);
-                    glUseProgram(0);
-                }
-            }
         }
 
         // --- Update input each frame ---

--- a/AlmondShell/include/aopenglrenderer.hpp
+++ b/AlmondShell/include/aopenglrenderer.hpp
@@ -165,8 +165,9 @@ namespace almondnamespace::openglrenderer
 
         //ensure_uploaded(*atlas);
 
-        auto it = opengltextures::opengl_gpu_atlases.find(atlas);
-        if (it == opengltextures::opengl_gpu_atlases.end()) {
+        auto& backend = opengltextures::get_opengl_backend();
+        auto it = backend.gpu_atlases.find(atlas);
+        if (it == backend.gpu_atlases.end()) {
             std::cerr << "[DrawSprite] GPU texture not found for atlas '" << atlas->name << "'\n";
             return;
         }

--- a/AlmondShell/include/aopengltextures.hpp
+++ b/AlmondShell/include/aopengltextures.hpp
@@ -70,8 +70,6 @@ namespace almondnamespace::opengltextures
         }
     };
 
-    inline std::unordered_map<const TextureAtlas*, AtlasGPU, TextureAtlasPtrHash, TextureAtlasPtrEqual> opengl_gpu_atlases;
-
     // forward declare OpenGL4State to avoid pulling in aopenglcontext here
     namespace openglcontext { struct OpenGL4State; }
     struct BackendData {
@@ -252,12 +250,13 @@ namespace almondnamespace::opengltextures
 
 
     inline void clear_gpu_atlases() noexcept {
-        for (auto& [_, gpu] : opengl_gpu_atlases) {
+        auto& backend = get_opengl_backend();
+        for (auto& [_, gpu] : backend.gpu_atlases) {
             if (gpu.textureHandle) {
                 glDeleteTextures(1, &gpu.textureHandle);
             }
         }
-        opengl_gpu_atlases.clear();
+        backend.gpu_atlases.clear();
         s_generation.fetch_add(1, std::memory_order_relaxed);
     }
 
@@ -314,9 +313,11 @@ namespace almondnamespace::opengltextures
             return;
         }
 
-        const int w = core::cli::window_width;
-        const int h = core::cli::window_height;
-        if (w == 0 || h == 0) {
+        GLint viewport[4] = { 0, 0, 0, 0 };
+        glGetIntegerv(GL_VIEWPORT, viewport);
+        const int w = viewport[2];
+        const int h = viewport[3];
+        if (w <= 0 || h <= 0) {
             std::cerr << "[DrawSprite] ERROR: Window dimensions are zero.\n";
             return;
         }

--- a/AlmondShell/src/acontext.cpp
+++ b/AlmondShell/src/acontext.cpp
@@ -288,7 +288,7 @@ namespace almondnamespace::core {
         openglContext->is_mouse_button_down = [](input::MouseButton b) { return input::is_mouse_button_down(b); };
 
         openglContext->registry_get = [](const char*) { return 0; };
-        openglContext->draw_sprite = [](SpriteHandle, std::span<const TextureAtlas* const>, float, float, float, float) {};
+        openglContext->draw_sprite = opengltextures::draw_sprite;
 
         openglContext->add_texture = [&](TextureAtlas& a, const std::string& n, const ImageData& i) {
             return AddTextureThunk(a, n, i, ContextType::OpenGL);


### PR DESCRIPTION
## Summary
- refactor the OpenGL texture backend to clear atlases via the backend data and compute sprite transforms from the active viewport
- add reusable OpenGL resource initialization and update the context bootstrap to support multiple windows while wiring draw_sprite into each context
- hook the renderer and context registration to use the shared backend texture map so GUI menus render their buttons instead of the raw atlas

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d1150a556c83338ea6500b00192338