### PR TITLE
Align SDL and SFML state metadata with shared window data

### DIFF
--- a/AlmondShell/include/asdlstate.hpp
+++ b/AlmondShell/include/asdlstate.hpp
@@ -23,50 +23,92 @@
  **************************************************************/
 #pragma once
 
-//#include "aplatform.hpp"
+#include "aplatform.hpp"
 #include "aengineconfig.hpp"
 
 #if defined(ALMOND_USING_SDL)
 
-//#include "arobusttime.hpp"
+#include "arobusttime.hpp"
 #include "acontextwindow.hpp"
 
+#include <array>
+#include <bitset>
+#include <functional>
 
 namespace almondnamespace::sdlcontext::state
 {
     struct SDL3State
     {
+        SDL3State()
+        {
+            window.width = DEFAULT_WINDOW_WIDTH;
+            window.height = DEFAULT_WINDOW_HEIGHT;
+            window.should_close = false;
+            screenWidth = window.width;
+            screenHeight = window.height;
+        }
+
         almondnamespace::contextwindow::WindowData window{};
 
         SDL_Event sdl_event{};
 
+        bool shouldClose{ false };
+        int screenWidth{ DEFAULT_WINDOW_WIDTH };
+        int screenHeight{ DEFAULT_WINDOW_HEIGHT };
+        bool running{ false };
+
+        std::function<void(int, int)> onResize{};
+
         struct MouseState
         {
-            bool down[5] = {};
-            bool pressed[5] = {};
+            std::array<bool, 5> down{};
+            std::array<bool, 5> pressed{};
+            std::array<bool, 5> prevDown{};
             int lastX = 0;
             int lastY = 0;
-        } mouse;
+        } mouse{};
 
         struct KeyboardState
         {
-            bool down[SDL_SCANCODE_COUNT] = {};
-            bool pressed[SDL_SCANCODE_COUNT] = {};
-        } keyboard;
+            std::bitset<SDL_SCANCODE_COUNT> down;
+            std::bitset<SDL_SCANCODE_COUNT> pressed;
+            std::bitset<SDL_SCANCODE_COUNT> prevDown;
+        } keyboard{};
+
+        time::Timer pollTimer = time::createTimer(1.0);
+        time::Timer fpsTimer = time::createTimer(1.0);
+        int frameCount = 0;
 
 #ifdef _WIN32
     private:
         WNDPROC oldWndProc_ = nullptr;
+        HWND parent_ = nullptr;
 
     public:
         WNDPROC getOldWndProc() const noexcept { return oldWndProc_; }
         void setOldWndProc(WNDPROC proc) noexcept { oldWndProc_ = proc; }
+
+        void setParent(HWND parent) noexcept { parent_ = parent; }
+        HWND getParent() const noexcept { return parent_; }
 #endif
 
-        HWND hwnd() const { return window.hwnd; }
-        HDC hdc() const { return window.hdc; }
-        HGLRC glrc() const { return window.glrc; }
-        SDL_Window* sdl_window() const { return window.sdl_window; }
+        void mark_should_close(bool value) noexcept
+        {
+            shouldClose = value;
+            window.should_close = value;
+        }
+
+        void set_dimensions(int w, int h) noexcept
+        {
+            screenWidth = w;
+            screenHeight = h;
+            window.set_size(w, h);
+        }
+
+        HWND hwnd() const noexcept { return window.hwnd; }
+        HDC hdc() const noexcept { return window.hdc; }
+        HGLRC glrc() const noexcept { return window.glrc; }
+        SDL_Window* sdl_window() const noexcept { return window.sdl_window; }
     };
 
     inline SDL3State s_sdlstate{};

--- a/AlmondShell/include/asfmlstate.hpp
+++ b/AlmondShell/include/asfmlstate.hpp
@@ -27,34 +27,81 @@
 
 #if defined(ALMOND_USING_SFML)
 
+#include "arobusttime.hpp"
 #include "acontextwindow.hpp"
 
-//#include <SFML/Graphics.hpp>
-//#include <SFML/Window.hpp> // for sf::RenderWindow, sf::Event, etc.
-    
+#include <array>
+#include <bitset>
+#include <functional>
+
+#include <SFML/Window/Event.hpp>
+#include <SFML/Window/Keyboard.hpp>
+#include <SFML/Window/Mouse.hpp>
 
 namespace almondnamespace::sfmlcontext::state
 {
-    // This is your global renderer state
     struct SFML3State
     {
-    almondnamespace::contextwindow::WindowData window{};
-        // Nothing fancy needed here yet.
-        // You can expand this with:
-        // - active shaders
-        // - viewports
-        // - default font
-        // - more later.
+        SFML3State()
+        {
+            window.width = DEFAULT_WINDOW_WIDTH;
+            window.height = DEFAULT_WINDOW_HEIGHT;
+            window.should_close = false;
+            screenWidth = window.width;
+            screenHeight = window.height;
+        }
 
-        // ✅ Safe getter, returns pointer, no UB
-    [[nodiscard]] sf::RenderWindow* get_sfml_window() noexcept
-    {
-        return window.sfml_window;
-    }
+        almondnamespace::contextwindow::WindowData window{};
 
+        sf::Event event{};
+
+        bool shouldClose{ false };
+        int screenWidth{ DEFAULT_WINDOW_WIDTH };
+        int screenHeight{ DEFAULT_WINDOW_HEIGHT };
+        bool running{ false };
+
+        std::function<void(int, int)> onResize{};
+
+        struct MouseState
+        {
+            std::array<bool, static_cast<std::size_t>(sf::Mouse::ButtonCount)> down{};
+            std::array<bool, static_cast<std::size_t>(sf::Mouse::ButtonCount)> pressed{};
+            std::array<bool, static_cast<std::size_t>(sf::Mouse::ButtonCount)> prevDown{};
+            int lastX = 0;
+            int lastY = 0;
+        } mouse{};
+
+        struct KeyboardState
+        {
+            std::bitset<sf::Keyboard::KeyCount> down;
+            std::bitset<sf::Keyboard::KeyCount> pressed;
+            std::bitset<sf::Keyboard::KeyCount> prevDown;
+        } keyboard{};
+
+        time::Timer pollTimer = time::createTimer(1.0);
+        time::Timer fpsTimer = time::createTimer(1.0);
+        int frameCount = 0;
+
+        [[nodiscard]] sf::RenderWindow* get_sfml_window() const noexcept
+        {
+            return window.sfml_window;
+        }
+
+        void mark_should_close(bool value) noexcept
+        {
+            shouldClose = value;
+            window.should_close = value;
+        }
+
+        void set_dimensions(int w, int h) noexcept
+        {
+            screenWidth = w;
+            screenHeight = h;
+            window.set_size(w, h);
+        }
     };
 
-    inline SFML3State s_sfmlstate{}; // for symmetry with other contexts
+    inline SFML3State s_sfmlstate{};
 }
 
 #endif // ALMOND_USING_SFML


### PR DESCRIPTION
## Summary
- expand the SDL3 state to mirror the shared OpenGL/Raylib shape, including timers, input tracking and window bookkeeping helpers
- give the SFML state the same default window sizing, timers, and input state mirrors so it stays consistent with WindowData

## Testing
- not run (header-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d15459ee508333a62b434b623bb652